### PR TITLE
Correction to apply_loss() in components.py

### DIFF
--- a/neuroptica/components.py
+++ b/neuroptica/components.py
@@ -299,7 +299,7 @@ def _get_mzi_partial_transfer_matrices(theta, phi, backward=False, cumulative=Tr
         return component_transfer_matrices
 
 def apply_loss(mzi, loss):
-    return np.array([[loss, 1],[1, loss]]) * mzi
+    return np.array([[loss, 0],[0, loss]]) @ mzi
 
 def get_loss(loss_dB, loss_diff=0, rv='gauss'):
     if rv == 'exp':


### PR DESCRIPTION
Currently, the apply_loss() function in components.py only applies losses to MZI transfer matrix elements [0,0] and [1,1].  This means that when an MZI is in the cross state, no loss is applied to the MZI.
My proposed correction converts the element-wise multiplication of the matrix [[loss,1],[1,loss]] to a matrix multiplication of [[loss,0],[0,loss].  This should apply loss to all elements of the MZI, allowing loss to appear in the cross state as well.